### PR TITLE
Support local unix sockets

### DIFF
--- a/mpd-notification.c
+++ b/mpd-notification.c
@@ -251,7 +251,7 @@ int main(int argc, char ** argv) {
 	}
 
 	/* disable artwork stuff if we are connected to a foreign host */
-	if (mpd_host != NULL)
+	if (mpd_host != NULL && mpd_host[0] != '/')
 		music_dir = NULL;
 
 	/* change directory to music base directory */


### PR DESCRIPTION
Absolute paths to AF_UNIX sockets can also be used to access MPD from any of the clients. So, `music_dir` doesn't need to be made `NULL` in such cases. 