### PR TITLE
Fix incorrect cover art

### DIFF
--- a/mpd-notification.c
+++ b/mpd-notification.c
@@ -464,6 +464,8 @@ int main(int argc, char ** argv) {
 		if (verbose > 0)
 			printf("%s: %s\n", program, notifystr);
 
+		notify_notification_clear_hints(notification);
+
 		/* Some notification daemons do not support handing pixbuf data. Write a PNG
 		 * file and give the path. */
 		if (file_workaround > 0 && pixbuf != NULL) {


### PR DESCRIPTION
- Clear any lingering hints that contain a previous track's cover.
- Load the cover image for all states. Ensures the latest cover is always used.

Resolves https://github.com/eworm-de/mpd-notification/issues/19.