### PR TITLE
Remove requirement of an icon theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ To compile and run `mpd-notification` you need:
 * [libnotify](http://library.gnome.org/devel/notification-spec/)
 * [libmpdclient](http://www.musicpd.org/libs/libmpdclient/)
 * [markdown](http://daringfireball.net/projects/markdown/) (HTML documentation)
-* `gnome-icon-theme` (or anything else that includes an icon named `audio-x-generic`)
 
 To use `mpd-notification` you probably want `mpd`, the
 [music player daemon](http://www.musicpd.org/) itself. ;)


### PR DESCRIPTION
[gnome-icon-theme](https://github.com/GNOME/gnome-icon-theme) seems to have been deprecated in favor of [adwaita-icon-theme](https://github.com/GNOME/adwaita-icon-theme) - both provide ``audio-x-generic``. For some distributions like Arch Linux, the latter is even installed as a dependency (libnotify > gtk3 > adwaita-icon-theme). 

However, mpd-notification does not need any icon theme to run - compiling and running fine without any installed. Some people, like myself, have notification icons disabled anyway.

I'd recommend one of two things:
- Replace references to gnome-icon-theme with adwaita-icon-theme
- Remove the requirement on an icon theme.

This PR is for the second option and removes references from the README.