### PR TITLE
Showing song length and elapsed time in notification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ install: install-bin install-doc
 
 install-bin: mpd-notification
 	$(INSTALL) -D -m0755 mpd-notification $(DESTDIR)/usr/bin/mpd-notification
+ifneq ($(CFLAGS_SYSTEMD),)
 	$(INSTALL) -D -m0644 systemd/mpd-notification.service $(DESTDIR)/usr/lib/systemd/user/mpd-notification.service
+endif
 
 install-doc: README.html
 	$(INSTALL) -D -m0644 README.md $(DESTDIR)/usr/share/doc/mpd-notification/README.md
@@ -64,5 +66,5 @@ distclean:
 
 release:
 	git archive --format=tar.xz --prefix=mpd-notification-$(VERSION)/ $(VERSION) > mpd-notification-$(VERSION).tar.xz
-	gpg -ab mpd-notification-$(VERSION).tar.xz
-	git notes --ref=refs/notes/signatures/tar add -C $$(git archive --format=tar --prefix=mpd-notification-$(VERSION)/ $(VERSION) | gpg --armor --detach-sign | git hash-object -w --stdin) $(VERSION)
+	gpg --armor --detach-sign --comment mpd-notification-$(VERSION).tar.xz mpd-notification-$(VERSION).tar.xz
+	git notes --ref=refs/notes/signatures/tar add -C $$(git archive --format=tar --prefix=mpd-notification-$(VERSION)/ $(VERSION) | gpg --armor --detach-sign --comment mpd-notification-$(VERSION).tar | git hash-object -w --stdin) $(VERSION)

--- a/config.def.h
+++ b/config.def.h
@@ -1,5 +1,5 @@
 /*
- * (C) 2011-2018 by Christian Hesse <mail@eworm.de>
+ * (C) 2011-2020 by Christian Hesse <mail@eworm.de>
  *
  * This software may be used and distributed according to the terms
  * of the GNU General Public License, incorporated herein by reference.

--- a/mpd-notification.c
+++ b/mpd-notification.c
@@ -1,5 +1,5 @@
 /*
- * (C) 2011-2018 by Christian Hesse <mail@eworm.de>
+ * (C) 2011-2020 by Christian Hesse <mail@eworm.de>
  *
  * This software may be used and distributed according to the terms
  * of the GNU General Public License, incorporated herein by reference.
@@ -389,7 +389,6 @@ int update_notification(int show_elapsed_time)
 int main(int argc, char ** argv) {
 	dictionary * ini = NULL;
 	GError * error = NULL;
-	unsigned short int errcount = 0;
 	const char * mpd_host, * mpd_port_str; 
 	unsigned mpd_port = MPD_PORT, mpd_timeout = MPD_TIMEOUT, notification_timeout = NOTIFICATION_TIMEOUT;
 	unsigned int i, version = 0, help = 0;
@@ -560,28 +559,12 @@ int main(int argc, char ** argv) {
             continue;
         }
 
-		while(notify_notification_show(notification, &error) == FALSE) {
-			if (errcount > 1) {
-				fprintf(stderr, "%s: Looks like we can not reconnect to notification daemon... Exiting.\n", program);
-				goto out10;
-			} else {
-				g_printerr("%s: Error \"%s\" while trying to show notification. Trying to reconnect.\n", program, error->message);
-				errcount++;
+		if (notify_notification_show(notification, &error) == FALSE) {
+			g_printerr("%s: Error showing notification: %s\n", program, error->message);
+			g_error_free(error);
 
-				g_error_free(error);
-				error = NULL;
-
-				notify_uninit();
-
-				usleep(500 * 1000);
-
-				if(notify_init(PROGNAME) == FALSE) {
-					fprintf(stderr, "%s: Could not initialize notify.\n", program);
-					goto out10;
-				}
-			}
+			goto out10;
 		}
-		errcount = 0;
 	}
     printf("While quited\n");
 

--- a/mpd-notification.h
+++ b/mpd-notification.h
@@ -1,5 +1,5 @@
 /*
- * (C) 2011-2018 by Christian Hesse <mail@eworm.de>
+ * (C) 2011-2020 by Christian Hesse <mail@eworm.de>
  *
  * This software may be used and distributed according to the terms
  * of the GNU General Public License, incorporated herein by reference.

--- a/systemd/mpd-notification.service
+++ b/systemd/mpd-notification.service
@@ -1,14 +1,20 @@
 [Unit]
 Description=MPD Notification
+Requires=dbus.socket
+PartOf=graphical-session.target
 # Do not require any service here! We do rely on mpd OR network (for
 # a remote mpd instance). So let the user care.
 # We want to order after, though. This makes sure the resource is
 # available on start and mpd-notification can cleanly disconnect on
 # system shutdown.
 After=mpd.service network.target network-online.target
+# Order after notification daemons to make sure it is stopped before.
+After=dunst.service xfce4-notifyd.service
+ConditionUser=!@system
 
 [Service]
 Type=notify
+Restart=on-failure
 ExecStart=/usr/bin/mpd-notification
 
 [Install]


### PR DESCRIPTION
I wanted to know easily the length and the elapsed time of the song I am currently listening to. Therefore I modified the code to show the length of the song when mpd state changed and to show elapsed time and length of the song when the signal SIGHUP is sent to mpd-notification.

The information on the length and elapsed time of the song is not shown by default. It can be activated in the configuration file with `show-time = true`.

Since the notification object was not updated when a signal was sent to mpd-notification, I factorized out of the `main` function the update of the notification object and called the newly created function from the signal handler. This way, the correct elapsed time is shown when a signal is sent to the process. Some variable, such as `music_dir`, were made global to make them accessible from the function that update the notification.

If something must be changed in my code, I will gladly modify it.