### PR TITLE
Makefile: don't install systemd service if there is no systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ install: install-bin install-doc
 
 install-bin: mpd-notification
 	$(INSTALL) -D -m0755 mpd-notification $(DESTDIR)/usr/bin/mpd-notification
+ifneq ($(CFLAGS_SYSTEMD),)
 	$(INSTALL) -D -m0644 systemd/mpd-notification.service $(DESTDIR)/usr/lib/systemd/user/mpd-notification.service
+endif
 
 install-doc: README.html
 	$(INSTALL) -D -m0644 README.md $(DESTDIR)/usr/share/doc/mpd-notification/README.md


### PR DESCRIPTION
Tested on Void Linux, sadly can't test with systemd