### PR TITLE
Makefile edit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ VERSION := 0.8.5
 all: mpd-notification README.html
 
 mpd-notification: mpd-notification.c mpd-notification.h config.h version.h
-	$(CC) $(CFLAGS) $(LDFLAGS) -o mpd-notification mpd-notification.c
+	$(CC) mpd-notification.c -o mpd-notification $(CFLAGS) $(LDFLAGS)
 
 config.h:
 	$(CP) config.def.h config.h


### PR DESCRIPTION
I'm running an Ubuntu-based system. When I attempted to compile the program using the original Makefile, I was getting heaps of linker errors. ('undefined reference to ...')

This PR fixes the issue, by moving all the object files arguments to the beginning of the GCC command in the Makefile.

Thanks for the great program :wink: 