### PR TITLE
add support for formats other than MP3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ CFLAGS_EXTRA	+= $(shell pkg-config --cflags --libs libnotify)
 CFLAGS_LIBAV	:= $(shell pkg-config --cflags --libs libavformat libavutil 2>/dev/null)
 ifneq ($(CFLAGS_LIBAV),)
 CFLAGS_EXTRA	+= -DHAVE_LIBAV $(CFLAGS_LIBAV)
-CFLAGS_EXTRA	+= -lmagic
 endif
 LDFLAGS	+= -Wl,-z,now -Wl,-z,relro -pie
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Requirements
 To compile and run `mpd-notification` you need:
 
 * [systemd ↗️](https://www.github.com/systemd/systemd)
-* [file ↗️](https://www.darwinsys.com/file/) for `libmagic`
 * [iniparser ↗️](https://github.com/ndevilla/iniparser)
 * [libav ↗️](https://libav.org/) or [ffmpeg ↗️](https://www.ffmpeg.org/)
 * [libnotify ↗️](https://developer.gnome.org/notification-spec/)
@@ -115,7 +114,7 @@ Artwork
 `mpd-notification` display album artwork you need to tell it where to look for
 artwork. You can do that by exporting `XDG_MUSIC_DIR` to your environment, by
 specifying `-m` or `--music-dir` on the command line or by setting `music-dir`
-in configuration file. `mpd-notification` reads album artwork from `mp3`
+in configuration file. `mpd-notification` reads album artwork from audio
 files, otherwise an image file containing the artwork needs to be placed
 in the same directory as the media file and named `cover.jpg`,
 `cover.png`, `folder.jpg` or `folder.png`.

--- a/mpd-notification.c
+++ b/mpd-notification.c
@@ -40,9 +40,6 @@ NotifyNotification * notification = NULL;
 struct mpd_connection * conn = NULL;
 uint8_t doexit = 0;
 uint8_t verbose = 0;
-#ifdef HAVE_LIBAV
-	magic_t magic = NULL;
-#endif
 
 /*** received_signal ***/
 void received_signal(int signal) {
@@ -83,7 +80,6 @@ GdkPixbuf * retrieve_artwork(const char * music_dir, const char * uri) {
 
 #ifdef HAVE_LIBAV
 	int i;
-	const char *magic_mime;
 	AVFormatContext * pFormatCtx = NULL;
 	GdkPixbufLoader * loader = NULL;
 
@@ -94,20 +90,6 @@ GdkPixbuf * retrieve_artwork(const char * music_dir, const char * uri) {
 	}
 
 	sprintf(uri_path, "%s/%s", music_dir, uri);
-
-	if ((magic_mime = magic_file(magic, uri_path)) == NULL) {
-		fprintf(stderr, "%s: We did not get a MIME type...\n", program);
-		goto image;
-	}
-
-	if (verbose > 0)
-		printf("%s: MIME type for %s is: %s\n", program, uri_path, magic_mime);
-
-	/* Are there more mime-types supporting embedded artwork? Tell me! */
-	if (strcmp(magic_mime, "audio/mp4") != 0 &&
-	    strcmp(magic_mime, "audio/mpeg") != 0 &&
-	    strcmp(magic_mime, "audio/x-m4a") != 0)
-		goto image;
 
 	if ((pFormatCtx = avformat_alloc_context()) == NULL) {
 		fprintf(stderr, "%s: avformat_alloc_context() failed.\n", program);
@@ -417,16 +399,6 @@ int main(int argc, char ** argv) {
 	if (verbose == 0)
 		av_log_set_level(AV_LOG_FATAL);
 
-	if ((magic = magic_open(MAGIC_MIME_TYPE)) == NULL) {
-		fprintf(stderr, "%s: Could not initialize magic library.\n", program);
-		goto out40;
-	}
-
-	if (magic_load(magic, NULL) != 0) {
-		fprintf(stderr, "%s: Could not load magic database: %s\n", program, magic_error(magic));
-		magic_close(magic);
-		goto out30;
-	}
 #endif
 
 	conn = mpd_connection_new(mpd_host, mpd_port, mpd_timeout * 1000);
@@ -590,11 +562,6 @@ out20:
 		mpd_connection_free(conn);
 
 out30:
-#ifdef HAVE_LIBAV
-	if (magic != NULL)
-		magic_close(magic);
-out40:
-#endif
 
 	if (ini != NULL)
 		iniparser_freedict(ini);

--- a/mpd-notification.h
+++ b/mpd-notification.h
@@ -40,7 +40,6 @@
 
 #ifdef HAVE_LIBAV
 #include <libavformat/avformat.h>
-#include <magic.h>
 #endif
 
 #include "config.h"


### PR DESCRIPTION
`libavformat` supports many more formats than just MP3 (see `ffmpeg -formats`), so I think it makes sense to avoid checking the MIME type of the file. This means that other widely-used formats such as FLAC and Opus would also be supported by `mpd-notification`.

If the file can't be recognized by `libavformat`, the call to `avformat_open_input` would simply fail and the rest of the program can move on. I have tested this and it works for me without any issues.

I'm curious as to why it's looking up the MIME type in the first place... Am I missing something important here?